### PR TITLE
Fix literal equality

### DIFF
--- a/src/serialization/patterns.ts
+++ b/src/serialization/patterns.ts
@@ -139,7 +139,7 @@ export const writePattern = (pattern: Pattern, index: InternalIndex, prefixes: P
     }
   }
   if (lte) {
-    if (didRange || didLiteral) {
+    if (didRange) {
       lt += boundary;
     } else {
       lt += separator + boundary;

--- a/test/quadstore/match.ts
+++ b/test/quadstore/match.ts
@@ -33,7 +33,7 @@ export const runMatchTests = () => {
 
         equalsQuadArray(matchedQuads, [quads[1]]);
       });
-
+      
       it('should match quads by predicate',  async function () {
         const { dataFactory, store } = this;
         const quads = [
@@ -76,10 +76,10 @@ export const runMatchTests = () => {
         ];
         const source = new ArrayIterator(quads);
         await waitForEvent(store.import(source), 'end', true);
-        const object = dataFactory.literal('o2', 'en-gb');
+        const object = dataFactory.literal('o', 'en-gb');
         const matchedQuads = await streamToArray(store.match(null, null, object));
 
-        equalsQuadArray(matchedQuads, [quads[1]]);
+        equalsQuadArray(matchedQuads, [quads[0]]);
       });
 
       it('should match quads by graph',  async function () {


### PR DESCRIPTION
Before, a literal (say, `"a"`) would match any value *beginning* with that string (say, `"a"`, `"ab"`, and `"abc"`). Now, it correctly only matches `"a"`.

Before, in the `gte`, we ended up comparing the next byte in the key with the `boundary`, which is a high value. Thus, looking for `"a"`, we'd find `"ab"`, because `"b" < boundary`. Instead, this case needs the `separator + boundary` used in other cases, because `"b" > separator`.

Fixes https://github.com/belayeng/quadstore/issues/160